### PR TITLE
Add full dynamodb access to IAM role

### DIFF
--- a/epimorphics/deployment/roles/provision/tasks/iam.yml
+++ b/epimorphics/deployment/roles/provision/tasks/iam.yml
@@ -23,6 +23,7 @@
     managed_policies:
       - "arn:aws:iam::{{ aws.account }}:policy/{{ sns.policy.name }}"
       - "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+      - "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess"
     description: "{{ sns.policy.description }}"
   register: role
 


### PR DESCRIPTION
Needed for data servers in HMLR to support standard reports. 
Addresses: https://github.com/epimorphics/hmlr-ansible-deployment/issues/63

But these permissions not needed elsewhere so not clear this the right place to put it.