### PR TITLE
Increase idle timeout

### DIFF
--- a/epimorphics/deployment/roles/provision/defaults/main.yml
+++ b/epimorphics/deployment/roles/provision/defaults/main.yml
@@ -54,6 +54,8 @@ lambda:
   runtime: "python3.8"
   version: "v2.06"
 
+elb:
+  timeout:  120 # seconds
 
 sns:
   policy:

--- a/epimorphics/deployment/roles/provision/tasks/finalise.yml
+++ b/epimorphics/deployment/roles/provision/tasks/finalise.yml
@@ -79,6 +79,7 @@
       Type: "{{ iter.type }}"
       Env: "{{ env }}"
       Inst: "{{ instance }}"
+    idle_timeout: 120 # seconds
     connection_draining_timeout: 120 # seconds
     state: present
     wait: True

--- a/epimorphics/deployment/roles/provision/tasks/finalise.yml
+++ b/epimorphics/deployment/roles/provision/tasks/finalise.yml
@@ -79,8 +79,8 @@
       Type: "{{ iter.type }}"
       Env: "{{ env }}"
       Inst: "{{ instance }}"
-    idle_timeout: 120 # seconds
-    connection_draining_timeout: 120 # seconds
+    idle_timeout: "{{ elb.timeout }}"
+    connection_draining_timeout: "{{ elb.timeout }}"
     state: present
     wait: True
   loop: "{{ (ec2_inst_lc | default([]) ) + (ec2_inst | default([]) ) }}"


### PR DESCRIPTION
Needs to match fuseki timeout which is 90/120s.

Tested and deployed for dev-data.